### PR TITLE
Chore/deploy on master

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -29,3 +29,7 @@ workflows:
       - "deploy":
           requires:
             - "test"
+          filters:
+            branches:
+              only:
+                - master

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,23 +1,31 @@
 version: 2
 
 jobs:
-  "deploy":
-    docker: 
+  "test":
+    docker: &BUILDIMAGE
       - image: jenkinsrise/cci-v2-docker-java8-gcloud:0.0.1
     working_directory: ~/cors-filter
-    
     steps:
       - checkout
+      - run: mvn test
+
+  "deploy":
+    docker: *BUILDIMAGE
+    working_directory: ~/cors-filter
+    steps:
       - run: git config --global user.name $JENKINS_USERNAME
       - run: git config --global user.email $JENKINS_EMAIL
-      - run: git config --global user.email $JENKINS_EMAIL
+      - checkout
       - add_ssh_keys:
           fingerprints:
             - "3f:e3:b8:f5:9e:58:a8:e0:70:03:38:58:4f:62:9a:97"
       - run: mvn deploy
- 
+
 workflows:
   version: 2
   build_and_deploy:
     jobs:
-      - "deploy"
+      - "test"
+      - "deploy":
+          requires:
+            - "test"

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,15 @@
+## Description
+Include a summary of the change. If this is fixing a defect, ensure to link to the issue this is fixing.
+
+## Motivation and Context
+Why is this change required? What problem does it solve?
+
+## How Has This Been Tested?
+Describe in detail how you tested your changes. Include details of your testing environment and link(s) for reviewers to validate.
+
+## Release Plan:
+- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
+- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed
+
+#### Release Checklist Items Skipped?
+If any Release Checklist items were intentionally skipped, please provide which ones and the reasons why


### PR DESCRIPTION
## Description
Deploy the component only on master branch.

## Motivation and Context
Currently the filter deploys on any branch, which is inconvenient.

## How Has This Been Tested?
Deployment still works, this commit has the master deployment commented out to test that:
https://circleci.com/workflow-run/ca6c9ff4-6d21-4173-9803-f329cf159094

## Release Plan:
N/A

#### Release Checklist Items Skipped?
N/A