### PR TITLE
Feature/add cors header

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,3 +119,83 @@ mvn verify
 ```
 mvn clean test -U
 ```
+
+* Add the filter to your WEB-INF/web.xml file, and map the URLs that should point to it:
+
+```xml
+  <filter>
+    <filter-name>CorsFilter</filter-name>
+    <filter-class>com.risevision.cors.filter.CorsFilter</filter-class>
+  </filter>
+  <filter-mapping>
+    <filter-name>CorsFilter</filter-name>
+    <url-pattern>/checkThirdPartyCookie</url-pattern>
+    <url-pattern>/createThirdPartyCookie</url-pattern>
+  </filter-mapping>
+```
+
+In this basic configuration, the filter just logs the origin header of a request, 
+if there is any, but does not add any HTTP header to the response.
+
+In order to set the origin header as the CORS `Access-Control-Allow-Origin`  
+value, a list of valid origins should be set using the `allow-origins` init
+parameter, for example:
+
+```xml
+  <filter>
+    <filter-name>CorsFilter</filter-name>
+    <filter-class>com.risevision.cors.filter.CorsFilter</filter-class>
+    <init-param>
+      <param-name>allow-origins</param-name>
+      <param-value>
+        *.risevision.com
+        rvauser.appspot.com
+        *rvauser2.appspot.com
+      </param-value>
+    </init-param>
+  </filter>
+  <filter-mapping>
+    <filter-name>CorsFilter</filter-name>
+    <url-pattern>/checkThirdPartyCookie</url-pattern>
+    <url-pattern>/createThirdPartyCookie</url-pattern>
+  </filter-mapping>
+```
+
+URLs such as 'rvauser.appspot.com' are exact HTTP or HTTPS matches;
+while URLs that start with '*' such as '*.risevision.com' can match any HTTP 
+or HTTPS requests coming from any risevision.com origin ( apps.risevision.com,
+store.risevision.com, apps-stage-10.risevision.com, etc. ).
+
+The filter also allow to optionally set fixed values for
+ `Access-Control-Allow-Methods` and `Access-Control-Allow-Credentials`,
+ for example:
+ 
+ 
+```xml
+  <filter>
+    <filter-name>CorsFilter</filter-name>
+    <filter-class>com.risevision.cors.filter.CorsFilter</filter-class>
+    <init-param>
+      <param-name>allow-origins</param-name>
+      <param-value>
+        *.risevision.com
+        rvauser.appspot.com
+        *rvauser2.appspot.com
+      </param-value>
+    </init-param>
+    <init-param>
+      <param-name>Access-Control-Allow-Methods</param-name>
+      <param-value>GET</param-value>
+    </init-param>
+    <init-param>
+      <param-name>Access-Control-Allow-Credentials</param-name>
+      <param-value>true</param-value>
+    </init-param>
+  </filter>
+  <filter-mapping>
+    <filter-name>CorsFilter</filter-name>
+    <url-pattern>/checkThirdPartyCookie</url-pattern>
+    <url-pattern>/createThirdPartyCookie</url-pattern>
+  </filter-mapping>
+```
+

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
     <packaging>jar</packaging>
     <groupId>com.risevision.cors</groupId>
     <artifactId>cors-filter</artifactId>
-    <version>1.0.0</version>
+    <version>1.1.0</version>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/src/main/java/com/risevision/cors/filter/CorsFilter.java
+++ b/src/main/java/com/risevision/cors/filter/CorsFilter.java
@@ -1,23 +1,40 @@
 package com.risevision.cors.filter;
 
-import java.io.IOException;
+import static com.risevision.cors.filter.Globals.*;
 
-import javax.servlet.ServletException;
-import javax.servlet.ServletRequest;
-import javax.servlet.ServletResponse;
+import java.io.IOException;
+import java.util.List;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+
 import javax.servlet.Filter;
 import javax.servlet.FilterChain;
 import javax.servlet.FilterConfig;
+import javax.servlet.ServletException;
+import javax.servlet.ServletRequest;
+import javax.servlet.ServletResponse;
 import javax.servlet.http.HttpServletRequest;
-
-import java.util.logging.Logger;
-import java.util.logging.Level;
+import javax.servlet.http.HttpServletResponse;
 
 public class CorsFilter implements Filter {
 
+    private static final Pattern SEPARATOR = Pattern.compile("[\\n\\s]+");
+
     private Logger logger;
 
-    private final String ORIGIN = "origin";
+    private List<UrlMatcher> allowedCorsOrigins = null;
+    private String allowMethods;
+    private String allowCredentials;
+
+    static List<UrlMatcher> toUrlMatcherList(String text) {
+      return SEPARATOR
+        .splitAsStream(text)
+        .filter(pattern -> pattern.length() > 0)
+        .map(UrlMatcher::create)
+        .collect(Collectors.toList());
+    }
 
     public CorsFilter(Logger logger) {
       this.logger = logger;
@@ -28,7 +45,34 @@ public class CorsFilter implements Filter {
     }
 
     @Override
-    public void init(FilterConfig filterConfig) throws ServletException {
+    public void init(FilterConfig config) throws ServletException {
+      String allowedOriginsString = config.getInitParameter(ALLOWED_ORIGINS_PARAM);
+
+      if(allowedOriginsString != null)
+        allowedCorsOrigins = toUrlMatcherList(allowedOriginsString.trim());
+
+      allowMethods = config.getInitParameter(ALLOWED_METHODS_HEADER);
+      allowCredentials = config.getInitParameter(ALLOWED_CREDENTIALS_HEADER);
+    }
+
+    private boolean isAllowedCorsOrigin(String origin) {
+      return allowedCorsOrigins.stream().anyMatch(matcher -> matcher.test(origin));
+    }
+
+    private void addCorsHeaders(HttpServletResponse response, String origin) {
+      if(!isAllowedCorsOrigin(origin)) {
+        logger.warning(String.format("Illegal CORS origin: %s", origin));
+
+        return;
+      }
+
+      response.setHeader(ALLOWED_ORIGIN_HEADER, origin);
+
+      if(allowMethods != null)
+        response.setHeader(ALLOWED_METHODS_HEADER, allowMethods);
+
+      if(allowCredentials != null)
+        response.setHeader(ALLOWED_CREDENTIALS_HEADER, allowCredentials);
     }
 
     @Override
@@ -36,10 +80,13 @@ public class CorsFilter implements Filter {
       logger.info("Starting cors filter execution");
 
       HttpServletRequest request = (HttpServletRequest) servletRequest;
-      String origin = request.getHeader(ORIGIN);
+      String origin = request.getHeader(ORIGIN_HEADER);
 
       if (origin != null) {
-        logger.log(Level.INFO, "CORS origin: {0}", origin);
+        if(allowedCorsOrigins != null)
+          addCorsHeaders((HttpServletResponse)servletResponse, origin);
+        else // original implementation, for transitional purposes
+          logger.log(Level.INFO, "CORS origin: {0}", origin);
       }
 
       filterChain.doFilter(servletRequest, servletResponse);

--- a/src/main/java/com/risevision/cors/filter/Globals.java
+++ b/src/main/java/com/risevision/cors/filter/Globals.java
@@ -1,0 +1,12 @@
+package com.risevision.cors.filter;
+
+public interface Globals {
+
+  final String ALLOWED_CREDENTIALS_HEADER = "Access-Control-Allow-Credentials";
+  final String ALLOWED_METHODS_HEADER = "Access-Control-Allow-Methods";
+  final String ALLOWED_ORIGIN_HEADER = "Access-Control-Allow-Origin";
+  final String ORIGIN_HEADER = "origin";
+
+  final String ALLOWED_ORIGINS_PARAM = "allow-origins";
+
+}

--- a/src/main/java/com/risevision/cors/filter/UrlMatcher.java
+++ b/src/main/java/com/risevision/cors/filter/UrlMatcher.java
@@ -1,0 +1,37 @@
+package com.risevision.cors.filter;
+
+import java.util.function.Predicate;
+import java.util.regex.Pattern;
+
+public class UrlMatcher implements Predicate<String> {
+
+  private static final String LITERAL_DOT = "[.]";
+  private static final Pattern DOT_REGEX = Pattern.compile(LITERAL_DOT);
+
+  private static String escapeDots(String text) {
+    return DOT_REGEX.matcher(text).replaceAll(LITERAL_DOT);
+  }
+
+  public static UrlMatcher create(String pattern) {
+    String regex;
+
+    if(pattern.startsWith("*"))
+      regex = "https?://[\\w.-]*" + escapeDots(pattern.substring(1));
+    else
+      regex = "https?://" + escapeDots(pattern);
+
+    return new UrlMatcher(regex);
+  }
+
+  private final Pattern pattern;
+
+  public UrlMatcher(String patternString) {
+    pattern = Pattern.compile(patternString);
+  }
+
+  @Override
+  public boolean test(String origin) {
+    return pattern.matcher(origin).matches();
+  }
+
+}

--- a/src/test/java/com/risevision/cors/filter/CorsFilterTest.java
+++ b/src/test/java/com/risevision/cors/filter/CorsFilterTest.java
@@ -1,44 +1,197 @@
 package com.risevision.cors.filter;
 
+import static com.risevision.cors.filter.Globals.*;
+
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 
 import javax.servlet.FilterChain;
+import javax.servlet.FilterConfig;
 import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import java.io.IOException;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 import static org.mockito.BDDMockito.given;
-import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.atLeastOnce;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyZeroInteractions;
 import static org.mockito.Matchers.*;
 
 import java.util.logging.Logger;
+import java.util.List;
+import java.util.function.Predicate;
 import java.util.logging.Level;
 
 
 public class CorsFilterTest {
+
+  private static final Predicate<UrlMatcher> MATCHES_APPS =
+    matcher -> matcher.test("https://apps.risevision.com");
+    private static final Predicate<UrlMatcher> MATCHES_APPS_STAGE =
+        matcher -> matcher.test("https://apps-stage-7.risevision.com");
+  private static final Predicate<UrlMatcher> MATCHES_RVA_USER =
+      matcher -> matcher.test("https://rvauser.risevision.com");
+  private static final Predicate<UrlMatcher> MATCHES_RVA_USER2 =
+    matcher -> matcher.test("https://rvauser2.appspot.com");
+  private static final Predicate<UrlMatcher> MATCHES_RVA_USER2_TEST =
+    matcher -> matcher.test("http://1-07-021.rvauser2.appspot.com");
+  private static final Predicate<UrlMatcher> MATCHES_RVA_USER2_STAGE =
+    matcher -> matcher.test("http://in-app-test-dot-rvauser2.appspot.com");
+  private static final Predicate<UrlMatcher> MATCHES_OTHER =
+    matcher -> matcher.test("https://www.apache.org");
+
   @Mock private Logger logger;  
   @Mock private HttpServletRequest httpServletRequest;
   @Mock private HttpServletResponse httpServletResponse;
   @Mock private FilterChain filterChain;
-
-  private final String ORIGIN = "origin";
+  @Mock private FilterConfig filterConfig;
 
   @Before public void setUp() {
     MockitoAnnotations.initMocks(this);
   }
 
   @Test
+  public void createsSimpleUrlMatcher() {
+    String param = "\n   apps.risevision.com\n    ";
+    List<UrlMatcher> origins = CorsFilter.toUrlMatcherList(param);
+
+    assertEquals(1, origins.size());
+    assertTrue(origins.stream().anyMatch(MATCHES_APPS));
+    assertFalse(origins.stream().anyMatch(MATCHES_APPS_STAGE));
+    assertFalse(origins.stream().anyMatch(MATCHES_RVA_USER));
+    assertFalse(origins.stream().anyMatch(MATCHES_RVA_USER2_TEST));
+    assertFalse(origins.stream().anyMatch(MATCHES_RVA_USER2_STAGE));
+    assertFalse(origins.stream().anyMatch(MATCHES_RVA_USER2));
+    assertFalse(origins.stream().anyMatch(MATCHES_OTHER));
+  }
+
+  @Test
+  public void createsMultipleUrlMatcher() {
+    String param = "\n   *.risevision.com\n   *rvauser.appspot.com\n   *rvauser2.appspot.com\n    ";
+    List<UrlMatcher> origins = CorsFilter.toUrlMatcherList(param);
+
+    assertEquals(3, origins.size());
+    assertTrue(origins.stream().anyMatch(MATCHES_APPS));
+    assertTrue(origins.stream().anyMatch(MATCHES_APPS_STAGE));
+    assertTrue(origins.stream().anyMatch(MATCHES_RVA_USER));
+    assertTrue(origins.stream().anyMatch(MATCHES_RVA_USER2_TEST));
+    assertTrue(origins.stream().anyMatch(MATCHES_RVA_USER2_STAGE));
+    assertTrue(origins.stream().anyMatch(MATCHES_RVA_USER2));
+    assertFalse(origins.stream().anyMatch(MATCHES_OTHER));
+  }
+
+  @Test
   public void logsAndCallsNextFilter() throws IOException, ServletException {
-    given(httpServletRequest.getHeader(ORIGIN)).willReturn("test.example.com");
+    given(httpServletRequest.getHeader(ORIGIN_HEADER)).willReturn("test.example.com");
     CorsFilter filter = new CorsFilter(logger);
     filter.doFilter(httpServletRequest, httpServletResponse, filterChain);
 
     verify(logger, atLeastOnce()).log(any(Level.class), anyString(), anyString());
-    verify(filterChain).doFilter(anyObject(), anyObject());
+    verify(filterChain).doFilter(httpServletRequest, httpServletResponse);
+    verifyZeroInteractions(httpServletResponse);
   }
+
+  @Test
+  public void addsCorsOriginToHttpCall() throws IOException, ServletException {
+    String origin = "http://apps.risevision.com";
+
+    given(httpServletRequest.getHeader(ORIGIN_HEADER)).willReturn(origin);
+    given(filterConfig.getInitParameter(ALLOWED_ORIGINS_PARAM)).willReturn("apps.risevision.com");
+
+    CorsFilter filter = new CorsFilter(logger);
+    filter.init(filterConfig);
+    filter.doFilter(httpServletRequest, httpServletResponse, filterChain);
+
+    verify(logger, never()).log(any(Level.class), anyString(), anyString());
+    verify(filterChain).doFilter(httpServletRequest, httpServletResponse);
+
+    verify(httpServletResponse, times(1)).setHeader(ALLOWED_ORIGIN_HEADER, origin);
+    verify(httpServletResponse, never()).setHeader(eq(ALLOWED_METHODS_HEADER), anyString());
+    verify(httpServletResponse, never()).setHeader(eq(ALLOWED_CREDENTIALS_HEADER), anyString());
+  }
+
+  @Test
+  public void addsCorsOriginToHttpsCall() throws IOException, ServletException {
+    String origin = "https://apps.risevision.com";
+
+    given(httpServletRequest.getHeader(ORIGIN_HEADER)).willReturn(origin);
+    given(filterConfig.getInitParameter(ALLOWED_ORIGINS_PARAM)).willReturn("apps.risevision.com");
+
+    CorsFilter filter = new CorsFilter(logger);
+    filter.init(filterConfig);
+    filter.doFilter(httpServletRequest, httpServletResponse, filterChain);
+
+    verify(logger, never()).log(any(Level.class), anyString(), anyString());
+    verify(filterChain).doFilter(httpServletRequest, httpServletResponse);
+
+    verify(httpServletResponse, times(1)).setHeader(ALLOWED_ORIGIN_HEADER, origin);
+    verify(httpServletResponse, never()).setHeader(eq(ALLOWED_METHODS_HEADER), anyString());
+    verify(httpServletResponse, never()).setHeader(eq(ALLOWED_CREDENTIALS_HEADER), anyString());
+  }
+
+  @Test
+  public void doesntAddCorsOriginToUnsupportedOrigin() throws IOException, ServletException {
+    String origin = "http://apps.piratevision.com";
+
+    given(httpServletRequest.getHeader(ORIGIN_HEADER)).willReturn(origin);
+    given(filterConfig.getInitParameter(ALLOWED_ORIGINS_PARAM)).willReturn("apps.risevision.com");
+
+    CorsFilter filter = new CorsFilter(logger);
+    filter.init(filterConfig);
+    filter.doFilter(httpServletRequest, httpServletResponse, filterChain);
+
+    verify(logger, never()).log(any(Level.class), anyString(), anyString());
+    verify(filterChain).doFilter(httpServletRequest, httpServletResponse);
+    verify(logger, times(1)).warning(anyString());
+    verifyZeroInteractions(httpServletResponse);
+  }
+
+  @Test
+  public void addsCorsMethodsHeaderIfConfigured() throws IOException, ServletException {
+    String origin = "https://apps.risevision.com";
+
+    given(httpServletRequest.getHeader(ORIGIN_HEADER)).willReturn(origin);
+    given(filterConfig.getInitParameter(ALLOWED_ORIGINS_PARAM)).willReturn("apps.risevision.com");
+    given(filterConfig.getInitParameter(ALLOWED_METHODS_HEADER)).willReturn("GET");
+
+    CorsFilter filter = new CorsFilter(logger);
+    filter.init(filterConfig);
+    filter.doFilter(httpServletRequest, httpServletResponse, filterChain);
+
+    verify(logger, never()).log(any(Level.class), anyString(), anyString());
+    verify(filterChain).doFilter(httpServletRequest, httpServletResponse);
+
+    verify(httpServletResponse, times(1)).setHeader(ALLOWED_ORIGIN_HEADER, origin);
+    verify(httpServletResponse, times(1)).setHeader(ALLOWED_METHODS_HEADER, "GET");
+    verify(httpServletResponse, never()).setHeader(eq(ALLOWED_CREDENTIALS_HEADER), anyString());
+  }
+
+  @Test
+  public void addsCorsCredentialsHeaderIfConfigured() throws IOException, ServletException {
+    String origin = "https://apps.risevision.com";
+
+    given(httpServletRequest.getHeader(ORIGIN_HEADER)).willReturn(origin);
+    given(filterConfig.getInitParameter(ALLOWED_ORIGINS_PARAM)).willReturn("apps.risevision.com");
+    given(filterConfig.getInitParameter(ALLOWED_CREDENTIALS_HEADER)).willReturn("true");
+
+    CorsFilter filter = new CorsFilter(logger);
+    filter.init(filterConfig);
+    filter.doFilter(httpServletRequest, httpServletResponse, filterChain);
+
+    verify(logger, never()).log(any(Level.class), anyString(), anyString());
+    verify(filterChain).doFilter(httpServletRequest, httpServletResponse);
+
+    verify(httpServletResponse, times(1)).setHeader(ALLOWED_ORIGIN_HEADER, origin);
+    verify(httpServletResponse, never()).setHeader(eq(ALLOWED_METHODS_HEADER), anyString());
+    verify(httpServletResponse, times(1)).setHeader(ALLOWED_CREDENTIALS_HEADER, "true");
+  }
+
 }

--- a/src/test/java/com/risevision/cors/filter/UrlMatcherTest.java
+++ b/src/test/java/com/risevision/cors/filter/UrlMatcherTest.java
@@ -1,0 +1,82 @@
+package com.risevision.cors.filter;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+public class UrlMatcherTest {
+
+  @Test
+  public void testHttpMatchOnFixedOrigin() {
+    UrlMatcher matcher = UrlMatcher.create("rvauser.appspot.com");
+
+    assertTrue(matcher.test("http://rvauser.appspot.com"));
+  }
+
+  @Test
+  public void testHttpsMatchOnFixedOrigin() {
+    UrlMatcher matcher = UrlMatcher.create("rvauser.appspot.com");
+
+    assertTrue(matcher.test("https://rvauser.appspot.com"));
+  }
+
+  @Test
+  public void testNoMatchOnFixedOrigin() {
+    UrlMatcher matcher = UrlMatcher.create("rvauser.appspot.com");
+
+    assertFalse(matcher.test("http://rvauser-appspot.com"));
+    assertFalse(matcher.test("httpk://rvauser.appspot.com"));
+    assertFalse(matcher.test("http://rvauser2.appspot.com"));
+    assertFalse(matcher.test("http://www.appspot.com"));
+  }
+
+  @Test
+  public void testDynamicHttpMatch() {
+    UrlMatcher matcher = UrlMatcher.create("*.risevision.com");
+
+    assertTrue(matcher.test("http://apps.risevision.com"));
+    assertTrue(matcher.test("http://rva.risevision.com"));
+    assertTrue(matcher.test("http://apps-stage-7.risevision.com"));
+    assertTrue(matcher.test("http://store-stage-0.risevision.com"));
+  }
+
+  @Test
+  public void testDynamicHttpsMatch() {
+    UrlMatcher matcher = UrlMatcher.create("*.risevision.com");
+
+    assertTrue(matcher.test("https://apps.risevision.com"));
+    assertTrue(matcher.test("https://rva.risevision.com"));
+    assertTrue(matcher.test("https://apps-stage-7.risevision.com"));
+    assertTrue(matcher.test("https://store-stage-0.risevision.com"));
+  }
+
+  @Test
+  public void testDynamicNoMatch() {
+    UrlMatcher matcher = UrlMatcher.create("*.risevision.com");
+
+    assertFalse(matcher.test("http//apps.risevision.com"));
+    assertFalse(matcher.test("http://rvarisevision.com"));
+    assertFalse(matcher.test("http://apps#stage-7.risevision.com"));
+    assertFalse(matcher.test("file://store-stage-0.risevision.com"));
+  }
+
+  @Test
+  public void testDynamicRvaUser2HttpMatch() {
+    UrlMatcher matcher = UrlMatcher.create("*rvauser2.appspot.com");
+
+    assertTrue(matcher.test("http://rvauser2.appspot.com"));
+    assertTrue(matcher.test("http://1-07-021.rvauser2.appspot.com"));
+    assertTrue(matcher.test("http://in-app-test-dot-rvauser2.appspot.com"));
+  }
+
+  @Test
+  public void testDynamicRvaUser2HttpsMatch() {
+    UrlMatcher matcher = UrlMatcher.create("*rvauser2.appspot.com");
+
+    assertTrue(matcher.test("https://rvauser2.appspot.com"));
+    assertTrue(matcher.test("https://1-07-021.rvauser2.appspot.com"));
+    assertTrue(matcher.test("https://in-app-test-dot-rvauser2.appspot.com"));
+  }
+
+}


### PR DESCRIPTION
## Description
CorsFilter adds CORS header if the origin header corresponds to a list of whitelisted origins.

## Motivation and Context
There's no whitelist of supported origins to our java-based servers, and there's no centralized code to set CORS headers.

## How Has This Been Tested?
Added the filter to a local server, and tried several configurations:

* No whitelist, to check that just HTTP header logging is done:

```xml
  <filter>
    <filter-name>CorsFilter</filter-name>
    <filter-class>com.risevision.cors.filter.CorsFilter</filter-class>
  </filter>
  <filter-mapping>
    <filter-name>CorsFilter</filter-name>
    <url-pattern>/*</url-pattern>
  </filter-mapping>
```

Any requests to any resource with no origin does nothing, and any request to any resource providing the 'Origin' header logs the attempt ( as it currently does ) - for example:

```bash
curl -H 'Origin: http://apache.org' -I http://localhost:8080/test/index.jsp
```

logs: 'INFO: CORS origin: http://apache.org'

* Whitelist set ( allowed-origins )

```xml
  <filter>
    <filter-name>CorsFilter</filter-name>
    <filter-class>com.risevision.cors.filter.CorsFilter</filter-class>
    <init-param>
      <param-name>allow-origins</param-name>
      <param-value>
        *.risevision.com
        *rvauser.appspot.com
        *rvauser2.appspot.com
      </param-value>
    </init-param>
  </filter>
  <filter-mapping>
    <filter-name>CorsFilter</filter-name>
    <url-pattern>/*</url-pattern>
  </filter-mapping>
```

In this case, a non-whitelisted call such as:

```bash
curl -H 'Origin: http://apache.org' -I http://localhost:8080/test/index.jsp
```

logs: 'WARNING: Illegal CORS origin: http://apache.org'

and whitelisted calls include `Access-Control-Allow-Origin` in the response, for example:

```bash
$ curl -H 'Origin: http://apps.risevision.com' -I http://localhost:8080/test/index.jsp
HTTP/1.1 200 
Access-Control-Allow-Origin: http://apps.risevision.com
```

and also:

```bash
$ curl -H 'Origin: https://1-07-021.rvauser2.appspot.com' -I http://localhost:8080/test/index.jsp
HTTP/1.1 200 
Access-Control-Allow-Origin: https://1-07-021.rvauser2.appspot.com
```

* Additional CORS headers:

```xml
  <filter>
    <filter-name>CorsFilter</filter-name>
    <filter-class>com.risevision.cors.filter.CorsFilter</filter-class>
    <init-param>
      <param-name>allow-origins</param-name>
      <param-value>
        *.risevision.com
        *rvauser.appspot.com
        *rvauser2.appspot.com
      </param-value>
    </init-param>
    <init-param>
      <param-name>Access-Control-Allow-Methods</param-name>
      <param-value>GET</param-value>
    </init-param>
    <init-param>
      <param-name>Access-Control-Allow-Credentials</param-name>
      <param-value>true</param-value>
    </init-param>
  </filter>
  <filter-mapping>
    <filter-name>CorsFilter</filter-name>
    <url-pattern>/*</url-pattern>
  </filter-mapping>
```

In this case, additional headers are added to the response:

```bash
$ curl -H 'Origin: https://apps.risevision.com' -I http://localhost:8080/test/index.jsp
HTTP/1.1 200 
Access-Control-Allow-Origin: https://apps.risevision.com
Access-Control-Allow-Methods: GET
Access-Control-Allow-Credentials: true
```

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed.
     - Does not affect production, so it can be merged once approved.
     - Documentation added to README.
     - Automated tests added.
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
No need to notify support.
